### PR TITLE
Disable the Travis OSX Mavericks build

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,7 @@ indent_style = tab
 max_line_length = off
 trim_trailing_whitespace = true
 
-[*.{md,txt}]
+[*.{md,txt,yml}]
 indent_size = 2
 indent_style = space
 trim_trailing_whitespace = false

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,10 +52,11 @@ matrix:
         # OS X Mavericks (10.9)
         # https://en.wikipedia.org/wiki/OS_X_Mavericks
         #
-        - os: osx
-          osx_image: beta-xcode6.2
-          env:
-              - ZIP_SUFFIX=osx-mavericks
+        # TODO - Disabled osx-mavericks because it times out during the build.
+        #- os: osx
+        #  osx_image: beta-xcode6.2
+        #  env:
+        #      - ZIP_SUFFIX=osx-mavericks
 
         # OS X Yosemite (10.10)
         # https://en.wikipedia.org/wiki/OS_X_Yosemite


### PR DESCRIPTION
The OSX Mavericks build consistently times out and will need to be investigated.
